### PR TITLE
Allow Codeowners creation from directly supplied content

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -70,7 +70,7 @@ func findCodeownersFile(wd string) (io.Reader, string, error) {
 	return nil, "", nil
 }
 
-// NewCodeowners -
+// NewCodeowners creates a Codeowners from the path to a local file.
 func NewCodeowners(path string) (*Codeowners, error) {
 	r, root, err := findCodeownersFile(path)
 	if err != nil {
@@ -79,8 +79,13 @@ func NewCodeowners(path string) (*Codeowners, error) {
 	if r == nil {
 		return nil, fmt.Errorf("No CODEOWNERS found in %s", path)
 	}
+	return NewCodeownersFromReader(r, root)
+}
+
+// NewCodeownersFromReader creates a Codeowners from a given Reader instance and root path.
+func NewCodeownersFromReader(r io.Reader, repoRoot string) (*Codeowners, error) {
 	co := &Codeowners{
-		repoRoot: root,
+		repoRoot: repoRoot,
 	}
 	co.patterns = parseCodeowners(r)
 	return co, nil

--- a/codeowners.go
+++ b/codeowners.go
@@ -70,8 +70,13 @@ func findCodeownersFile(wd string) (io.Reader, string, error) {
 	return nil, "", nil
 }
 
-// NewCodeowners creates a Codeowners from the path to a local file.
+// Deprecated: Use FromFile(path) instead.
 func NewCodeowners(path string) (*Codeowners, error) {
+	return FromFile(path)
+}
+
+// FromFile creates a Codeowners from the path to a local file.
+func FromFile(path string) (*Codeowners, error) {
 	r, root, err := findCodeownersFile(path)
 	if err != nil {
 		return nil, err
@@ -79,11 +84,11 @@ func NewCodeowners(path string) (*Codeowners, error) {
 	if r == nil {
 		return nil, fmt.Errorf("No CODEOWNERS found in %s", path)
 	}
-	return NewCodeownersFromReader(r, root)
+	return FromReader(r, root)
 }
 
-// NewCodeownersFromReader creates a Codeowners from a given Reader instance and root path.
-func NewCodeownersFromReader(r io.Reader, repoRoot string) (*Codeowners, error) {
+// FromReader creates a Codeowners from a given Reader instance and root path.
+func FromReader(r io.Reader, repoRoot string) (*Codeowners, error) {
 	co := &Codeowners{
 		repoRoot: repoRoot,
 	}

--- a/codeowners_test.go
+++ b/codeowners_test.go
@@ -283,15 +283,23 @@ func cwd() string {
 	return cwd
 }
 
-func ExampleNewCodeowners() {
-	c, _ := NewCodeowners(cwd())
+func ExampleFromFile() {
+	c, _ := FromFile(cwd())
+	fmt.Println(c.patterns[0])
+	// Output:
+	// *	@hairyhenderson
+}
+
+func ExampleFromReader() {
+	reader := strings.NewReader(sample2)
+	c, _ := FromReader(reader)
 	fmt.Println(c.patterns[0])
 	// Output:
 	// *	@hairyhenderson
 }
 
 func ExampleCodeowners_Owners() {
-	c, _ := NewCodeowners(cwd())
+	c, _ := FromFile(cwd())
 	owners := c.Owners("README.md")
 	for i, o := range owners {
 		fmt.Printf("Owner #%d is %s\n", i, o)


### PR DESCRIPTION
This adds a secondary API to allow usage of this library without requiring a local filesystem.
Specifically came from needing to process data within a GitHub bot implementation, where the CODEOWNERS data is being loaded directly via the GitHub API.