### PR TITLE
Allow for multi-line discovery of owners

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -149,16 +149,18 @@ func (c *Codeowners) Owners(path string) []string {
 		path = strings.Replace(path, c.repoRoot, "", 1)
 	}
 
+	var owners []string
+
 	// Order is important; the last matching pattern takes the most precedence.
 	for i := len(c.Patterns) - 1; i >= 0; i-- {
 		p := c.Patterns[i]
 
 		if p.re.MatchString(path) {
-			return p.Owners
+			owners = append(owners, p.Owners...)
 		}
 	}
 
-	return nil
+	return owners
 }
 
 // based on github.com/sabhiram/go-gitignore


### PR DESCRIPTION
This commit introduces a small bit of functionality which allows
for matching an entire CODEOWNERS file, replacing the previous
functionality of simply matching the first instance of a code
owner.

Signed-off-by: Alexander Jung <alex@nderjung.net>