### PR TITLE
Ignore GitLab sections

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -129,6 +129,9 @@ func parseCodeowners(r io.Reader) []Codeowner {
 		if len(fields) > 0 && strings.HasPrefix(fields[0], "#") {
 			continue
 		}
+		if len(fields) > 0 && strings.HasPrefix(fields[0], "[") && strings.HasSuffix(fields[len(fields) -1], "]") {
+			continue
+		}
 		if len(fields) > 1 {
 			fields = combineEscapedSpaces(fields)
 			c, _ := NewCodeowner(fields[0], fields[1:])

--- a/codeowners_test.go
+++ b/codeowners_test.go
@@ -24,6 +24,10 @@ var (
 docs/**	@org/docteam @joe`
 	sample2 = `* @hairyhenderson`
 	sample3 = `baz/* @baz @qux`
+	sample4 = `[test]
+*   @everyone
+[test2][2]
+*/foo @everyoneelse`
 
 	codeowners []Codeowner
 )
@@ -36,6 +40,17 @@ func TestParseCodeowners(t *testing.T) {
 		co("*", []string{"@everyone"}),
 		co("foobar/", []string{"someone@else.com"}),
 		co("docs/**", []string{"@org/docteam", "@joe"}),
+	}
+	assert.Equal(t, expected, c)
+}
+
+func TestParseCodeownersSections(t *testing.T) {
+	t.Parallel()
+	r := bytes.NewBufferString(sample4)
+	c := parseCodeowners(r)
+	expected := []Codeowner{
+		co("*", []string{"@everyone"}),
+		co("*/foo", []string{"@everyoneelse"}),
 	}
 	assert.Equal(t, expected, c)
 }


### PR DESCRIPTION
GitLab-flavored CODEOWNERS style supports sections within [] characters.

This change ignores them as it is for comments.