### PR TITLE
Handle GItLab flavored CODEOWNERS syntax sections

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -136,11 +136,7 @@ func parseCodeowners(r io.Reader) ([]Codeowner, error) {
 	for s.Scan() {
 		line := s.Text()
 		if isSection(line) {
-			defaultOwners = nil
-			index := strings.LastIndex(line, "]")
-			if index != -1 && len(line) > index+1 {
-				defaultOwners = strings.Fields(strings.TrimSpace(line[index+1:]))
-			}
+			defaultOwners = parseDefaultOwners(line)
 			continue
 		}
 		fields := strings.Fields(line)
@@ -164,6 +160,14 @@ func parseCodeowners(r io.Reader) ([]Codeowner, error) {
 		}
 	}
 	return co, nil
+}
+
+func parseDefaultOwners(line string) []string {
+	index := strings.LastIndex(line, "]")
+	if index != -1 && len(line) > index+1 {
+		return strings.Fields(strings.TrimSpace(line[index+1:]))
+	}
+	return nil
 }
 
 // if any of the elements ends with a \, it was an escaped space

--- a/codeowners_test.go
+++ b/codeowners_test.go
@@ -80,8 +80,37 @@ docs/*.md @mdowner
 space/test\ space/ @spaceowner
 `
 
+	gitlabSections = `# This is a GitLab section with default owners.
+[Team 1][1] @default1 @default2
+*.js	@js-owner
+*.txt
+
+# This is another section with new defaults.
+[Team 2] @default3 @default4
+*.java @java-owner
+*
+
+# This is an optional sections without defaults.
+^[Team 3]
+*.go @team-1
+`
+
 	codeowners []Codeowner
 )
+
+func TestParseGitLabSectionsWithDefaults(t *testing.T) {
+	t.Parallel()
+	r := bytes.NewBufferString(gitlabSections)
+	c, _ := parseCodeowners(r)
+	expected := []Codeowner{
+		co("*.js", []string{"@js-owner"}),
+		co("*.txt", []string{"@default1", "@default2"}),
+		co("*.java", []string{"@java-owner"}),
+		co("*", []string{"@default3", "@default4"}),
+		co("*.go", []string{"@team-1"}),
+	}
+	assert.Equal(t, expected, c)
+}
 
 func TestParseCodeowners(t *testing.T) {
 	t.Parallel()

--- a/codeowners_test.go
+++ b/codeowners_test.go
@@ -86,7 +86,7 @@ space/test\ space/ @spaceowner
 func TestParseCodeowners(t *testing.T) {
 	t.Parallel()
 	r := bytes.NewBufferString(sample)
-	c := parseCodeowners(r)
+	c, _ := parseCodeowners(r)
 	expected := []Codeowner{
 		co("*", []string{"@everyone"}),
 		co("foobar/", []string{"someone@else.com"}),
@@ -98,7 +98,7 @@ func TestParseCodeowners(t *testing.T) {
 func TestParseCodeownersSections(t *testing.T) {
 	t.Parallel()
 	r := bytes.NewBufferString(sample4)
-	c := parseCodeowners(r)
+	c, _ := parseCodeowners(r)
 	expected := []Codeowner{
 		co("*", []string{"@everyone"}),
 		co("*/foo", []string{"@everyoneelse"}),
@@ -111,7 +111,7 @@ func BenchmarkParseCodeowners(b *testing.B) {
 	var c []Codeowner
 
 	for n := 0; n < b.N; n++ {
-		c = parseCodeowners(r)
+		c, _ = parseCodeowners(r)
 	}
 
 	codeowners = c
@@ -164,7 +164,7 @@ func co(pattern string, owners []string) Codeowner {
 func TestFullParseCodeowners(t *testing.T) {
 	t.Parallel()
 
-	c := parseCodeowners(strings.NewReader(fullSample))
+	c, _ := parseCodeowners(strings.NewReader(fullSample))
 	codeowners := &Codeowners{
 		repoRoot: "/build",
 		Patterns: c,

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hairyhenderson/go-codeowners
+module github.com/matteosilv/go-codeowners
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/matteosilv/go-codeowners
+module github.com/hairyhenderson/go-codeowners
 
 go 1.20
 


### PR DESCRIPTION
Handle sections in GitLab specific CODEOWNERS syntax + tests

https://docs.gitlab.com/ee/user/project/codeowners/reference.html#sections

BONUS, propagating error in regex compilation that were hide on top with _