### PR TITLE
Treat /foo pattern as top-level directory prefix

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -259,8 +259,10 @@ func getPattern(line string) (*regexp.Regexp, error) {
 	var expr = ""
 	if strings.HasSuffix(line, "/") {
 		expr = line + "(|.*)$"
-	} else {
+	} else if strings.HasSuffix(line, "/([^/]*)") {
 		expr = line + "$"
+	} else {
+		expr = line + "($|/.+$)"
 	}
 	if strings.HasPrefix(expr, "/") {
 		expr = "^(|/)" + expr[1:]

--- a/codeowners.go
+++ b/codeowners.go
@@ -256,18 +256,22 @@ func getPattern(line string) (*regexp.Regexp, error) {
 	line = strings.ReplaceAll(line, magicStar, "*")
 
 	// Temporary regex
-	var expr = ""
-	if strings.HasSuffix(line, "/") {
+	expr := ""
+
+	switch {
+	case strings.HasSuffix(line, "/"):
 		expr = line + "(|.*)$"
-	} else if strings.HasSuffix(line, "/([^/]*)") {
+	case strings.HasSuffix(line, "/([^/]*)"):
 		expr = line + "$"
-	} else {
+	default:
 		expr = line + "($|/.+$)"
 	}
+
 	if strings.HasPrefix(expr, "/") {
 		expr = "^(|/)" + expr[1:]
 	} else {
 		expr = "^(|.*/)" + expr
 	}
+
 	return regexp.Compile(expr)
 }

--- a/codeowners_test.go
+++ b/codeowners_test.go
@@ -78,6 +78,10 @@ docs/*.md @mdowner
 
 # this example tests an escaped space in the path
 space/test\ space/ @spaceowner
+
+# In this example, @infra owns any file and directory in the
+# '/terraform' directory in the root of your repository.
+/terraform @infra
 `
 
 	gitlabSections = `# This is a GitLab section with default owners.
@@ -229,6 +233,7 @@ func TestFullParseCodeowners(t *testing.T) {
 		{"docs/foo.js", []string{"@doctocat"}},
 		{"/docs/foo.js", []string{"@doctocat"}},
 		{"/space/test space/doc1.txt", []string{"@spaceowner"}},
+		{"/terraform/kubernetes", []string{"@infra"}},
 	}
 
 	for _, d := range data {
@@ -261,6 +266,15 @@ func TestOwners(t *testing.T) {
 		{[]Codeowner{
 			co("*", foo),
 			co("/a/**", bar)}, "/a/bb/file", bar},
+		{[]Codeowner{
+			co("*", []string{"@foo", "@bar"}),
+			co("/bar/", bar)}, "/bar/quux", bar},
+		{[]Codeowner{
+			co("*", []string{"@foo", "@bar"}),
+			co("/bar", bar)}, "/bar", bar},
+		{[]Codeowner{
+			co("*", []string{"@foo", "@bar"}),
+			co("/bar", bar)}, "/bar/quux", bar},
 	}
 
 	for _, d := range data {


### PR DESCRIPTION
As stated in the [`gitignore`](https://git-scm.com/docs/gitignore) docs:

> If there is a separator at the end of the pattern then the pattern
> will only match directories, otherwise the pattern can match both
> files and directories.

This fixes this by removing anchoring the pattern regular expression at the end if the pattern do not end in a separator or `/*` (eg. not nested).