### PR TITLE
Fix pattern not ending in slash not matching directory

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -264,7 +264,7 @@ func getPattern(line string) (*regexp.Regexp, error) {
 	case strings.HasSuffix(line, "/([^/]*)"):
 		expr = line + "$"
 	default:
-		expr = line + "($|/.+$)"
+		expr = line + "($|/.*$)"
 	}
 
 	if strings.HasPrefix(expr, "/") {

--- a/codeowners_test.go
+++ b/codeowners_test.go
@@ -57,6 +57,11 @@ docs/**	@org/docteam @joe`
 # subdirectories.
 /build/logs/ @doctocat
 
+# In this example, @fooowner owns any files in the /cells/foo
+# directory at the root of the repository and any of its
+# subdirectories and files.
+/cells/foo @fooowner
+
 # The 'docs/*' pattern will match files like
 # 'docs/getting-started.md' but not further nested files like
 # 'docs/build-app/troubleshooting.md'.
@@ -234,6 +239,11 @@ func TestFullParseCodeowners(t *testing.T) {
 		{"/docs/foo.js", []string{"@doctocat"}},
 		{"/space/test space/doc1.txt", []string{"@spaceowner"}},
 		{"/terraform/kubernetes", []string{"@infra"}},
+
+		{"/cells/foo", []string{"@fooowner"}},
+		{"/cells/foo/", []string{"@fooowner"}},
+		{"/cells/foo/bar", []string{"@fooowner"}},
+		{"/cells/foo/bar/quux", []string{"@fooowner"}},
 	}
 
 	for _, d := range data {


### PR DESCRIPTION
I've found that when having an entry like `/foo/bar @foo` in the CODEOWNERS file the library properly reports `@foo` as the owner for `/foo/bar` and `/foo/bar/quux` but not for `/foo/bar/` (note the slash at the end). This PR adds tests for this case and fixes the regular expression to take this case into account.