### PR TITLE
Reduce allocations

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -225,21 +225,14 @@ func (c *Codeowners) Owners(path string) []string {
 
 // precompile all regular expressions
 var (
-	reCommentIgnore = regexp.MustCompile(`^(\\#|\\!)`)
-	rePrependSlash  = regexp.MustCompile(`([^\/+])/.*\*\.`)
-	reEscapeDot     = regexp.MustCompile(`\.`)
-	reDoubleStar1   = regexp.MustCompile(`/\*\*/`)
-	reDoubleStar2   = regexp.MustCompile(`\*\*/`)
-	reDoubleStar3   = regexp.MustCompile(`/\*\*`)
-	reEscapeStar1   = regexp.MustCompile(`\\\*`)
-	reEscapeStar2   = regexp.MustCompile(`\*`)
+	rePrependSlash = regexp.MustCompile(`([^\/+])/.*\*\.`)
 )
 
 // based on github.com/sabhiram/go-gitignore
 // but modified so that 'dir/*' only matches files in 'dir/'
 func getPattern(line string) (*regexp.Regexp, error) {
 	// when # or ! is escaped with a \
-	if reCommentIgnore.MatchString(line) {
+	if strings.HasPrefix(line, `\#`) || strings.HasPrefix(line, `\!`) {
 		line = line[1:]
 	}
 
@@ -249,7 +242,7 @@ func getPattern(line string) (*regexp.Regexp, error) {
 	}
 
 	// Handle escaping the "." char
-	line = reEscapeDot.ReplaceAllString(line, `\.`)
+	line = strings.ReplaceAll(line, ".", `\.`)
 
 	magicStar := "#$~"
 
@@ -257,13 +250,13 @@ func getPattern(line string) (*regexp.Regexp, error) {
 	if strings.HasPrefix(line, "/**/") {
 		line = line[1:]
 	}
-	line = reDoubleStar1.ReplaceAllString(line, `(/|/.+/)`)
-	line = reDoubleStar2.ReplaceAllString(line, `(|.`+magicStar+`/)`)
-	line = reDoubleStar3.ReplaceAllString(line, `(|/.`+magicStar+`)`)
+	line = strings.ReplaceAll(line, `/**/`, `(/|/.+/)`)
+	line = strings.ReplaceAll(line, `**/`, `(|.`+magicStar+`/)`)
+	line = strings.ReplaceAll(line, `/**`, `(|/.`+magicStar+`)`)
 
 	// Handle escaping the "*" char
-	line = reEscapeStar1.ReplaceAllString(line, `\`+magicStar)
-	line = reEscapeStar2.ReplaceAllString(line, `([^/]*)`)
+	line = strings.ReplaceAll(line, `\*`, `\`+magicStar)
+	line = strings.ReplaceAll(line, `*`, `([^/]*)`)
 
 	// Handle escaping the "?" char
 	line = strings.ReplaceAll(line, "?", `\?`)

--- a/codeowners_test.go
+++ b/codeowners_test.go
@@ -145,10 +145,12 @@ func TestParseCodeownersSections(t *testing.T) {
 }
 
 func BenchmarkParseCodeowners(b *testing.B) {
-	r := bytes.NewBufferString(sample)
 	var c []Codeowner
 
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		r := bytes.NewBufferString(sample)
+		b.StartTimer()
 		c, _ = parseCodeowners(r)
 	}
 


### PR DESCRIPTION
This PR reduces the allocations in `getPattern` and it also improves the overall speed of the function.

First note that I had to fix the existing benchmark, as the reader was being read only once in the first iteration, and afterwards it was always empty, thus `parseCodeowners` was parsing an empty file.

These were the metrics before the change:

    $ go test -benchmem -bench=.
    goos: darwin
    goarch: arm64
    pkg: github.com/hairyhenderson/go-codeowners
    BenchmarkParseCodeowners-10      2677503               465.3 ns/op          4096 B/op          1 allocs/op
    PASS
    ok      github.com/hairyhenderson/go-codeowners 2.255s

After the change it's not showing more realistic data:

    $ go test -benchmem -bench=.
    goos: darwin
    goarch: arm64
    pkg: github.com/hairyhenderson/go-codeowners
    BenchmarkParseCodeowners-10        31054             38910 ns/op           61424 B/op        641 allocs/op
    PASS
    ok      github.com/hairyhenderson/go-codeowners 3.529s

Then we move out of `getPattern` all regexp compilations, reducing the allocations ~62% and the performance in ~55%. Finally uses `strings.ReplaceAll` instead of the regexp versions when possible. These are the end results:

```
$ benchstat main.log stringsreplace.log
goos: darwin
goarch: arm64
pkg: github.com/hairyhenderson/go-codeowners
                   │  main.log   │         stringsreplace.log          │
                   │   sec/op    │   sec/op     vs base                │
ParseCodeowners-10   38.72µ ± 2%   15.21µ ± 7%  -60.73% (p=0.000 n=10)

                   │   main.log   │          stringsreplace.log          │
                   │     B/op     │     B/op      vs base                │
ParseCodeowners-10   59.95Ki ± 0%   25.98Ki ± 0%  -56.66% (p=0.000 n=10)

                   │  main.log  │         stringsreplace.log         │
                   │ allocs/op  │ allocs/op   vs base                │
ParseCodeowners-10   641.0 ± 0%   194.0 ± 0%  -69.73% (p=0.000 n=10)
```