### PR TITLE
Allow checking when no codeowners file is found

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -13,6 +13,9 @@ import (
 	"strings"
 )
 
+// ErrNoCodeownersFound is returned when no CODEOWNERS file is found
+var ErrNoCodeownersFound = errors.New("no CODEOWNERS found")
+
 // Codeowners - patterns/owners mappings for the given repo
 type Codeowners struct {
 	repoRoot string
@@ -106,7 +109,7 @@ func FromFileWithFS(fsys fs.FS, path string) (*Codeowners, error) {
 		return nil, err
 	}
 	if r == nil {
-		return nil, fmt.Errorf("no CODEOWNERS found in %s", path)
+		return nil, fmt.Errorf("%w in %s", ErrNoCodeownersFound, path)
 	}
 	return FromReader(r, root)
 }


### PR DESCRIPTION
This will allow checking when no codeowners exists:

```
fsys := os.DirFS(cwd())

c, err  := FromFileWithFS(fsys, ".")

if errros.Is(err, ErrNoCodeownersFound) {
  // handle this case
}
```

